### PR TITLE
Fixed NullReferenceException in ShadowManager.KryptonFormOnClosing

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/General/ShadowManager.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/General/ShadowManager.cs
@@ -91,10 +91,13 @@ namespace ComponentFactory.Krypton.Toolkit
             _allowDrawing = false;
             FlashWindowExListener.FlashEvent -= OnFlashWindowExListenerOnFlashEvent;
 
-            foreach (VisualShadowBase shadowForm in _shadowForms)
+            if (_shadowForms != null)
             {
-                shadowForm.Visible = false;
-                shadowForm.Dispose();
+                foreach (VisualShadowBase shadowForm in _shadowForms)
+                {
+                    shadowForm.Visible = false;
+                    shadowForm.Dispose();
+                }
             }
 
         }


### PR DESCRIPTION
Hi Peter - thanks for your great work on the Krypton suite. I've just switched over from Phil's original commercial product to your 4.7.2 NuGet package and it's looking great so far. 

I experienced a NullReferenceException in my application today, in the method "ShadowManager.KryptonFormOnClosing". Some of my KryptonForm windows have the UseDropShadow property set to false, so I suspect that would mean shadow forms aren't created. 

I haven't been able to reproduce the issue (it seems to be a race condition, maybe my form was closed before being shown) but I can see only one possible way it could occur, so I've fixed that. If there is a chance that the _shadowForms array could contain null entries, let me know and I'll update the fix to protect against that too.

Cheers,

Dave.